### PR TITLE
Changed to > instead of >= to perserve max length when chopping off a…

### DIFF
--- a/ExploringStrcpy/main.c
+++ b/ExploringStrcpy/main.c
@@ -73,7 +73,7 @@ int main(void) {
    
    // strncpy(dest,msg,MAX_MSG_LENGTH);
 
-   // if (strlen(msg)>=MAX_MSG_LENGTH) {
+   // if (strlen(msg)>MAX_MSG_LENGTH) {
    //    dest[MAX_MSG_LENGTH] = '\0';
    // }
 


### PR DESCRIPTION
… string that is too large